### PR TITLE
Add Unity tests for stack and bubble sort

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,13 +2,13 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "Build and Run Tests",
+            "label": "Build Leap Tests",
             "type": "shell",
             "command": "clang",
             "args": [
-                "-o", "${workspaceFolder}/problem_sets/leap/test", 
-                "${workspaceFolder}/problem_sets/leap/test.c", 
-                "${workspaceFolder}/problem_sets/leap/leap.c", 
+                "-o", "${workspaceFolder}/tests/problem_sets/leap/test",
+                "${workspaceFolder}/tests/problem_sets/leap/test.c",
+                "${workspaceFolder}/problem_sets/leap/leap.c",
                 "${workspaceFolder}/../Unity/src/unity.c"
             ],
             "group": {
@@ -16,18 +16,41 @@
                 "isDefault": true
             },
             "problemMatcher": [],
-            "detail": "Compiles the Unity test file and runs it."
+            "detail": "Compiles the leap year Unity tests."
         },
         {
-            "label": "Run Tests",
+            "label": "Run Leap Tests",
             "type": "shell",
-            "command": "${workspaceFolder}/problem_sets/leap/test",
+            "command": "${workspaceFolder}/tests/problem_sets/leap/test",
             "group": {
                 "kind": "test",
                 "isDefault": true
             },
             "problemMatcher": [],
-            "detail": "Runs the compiled test binary."
+            "detail": "Runs the compiled leap year test binary."
+        },
+        {
+            "label": "Build Stack & Sort Tests",
+            "type": "shell",
+            "command": "clang",
+            "args": [
+                "-o", "${workspaceFolder}/tests/test",
+                "${workspaceFolder}/tests/test.c",
+                "${workspaceFolder}/tests/stack.c",
+                "${workspaceFolder}/tests/sort.c",
+                "${workspaceFolder}/../Unity/src/unity.c"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "detail": "Compiles stack and bubble sort Unity tests."
+        },
+        {
+            "label": "Run Stack & Sort Tests",
+            "type": "shell",
+            "command": "${workspaceFolder}/tests/test",
+            "group": "test",
+            "problemMatcher": [],
+            "detail": "Runs the stack and bubble sort test binary."
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -188,7 +188,9 @@ Windows requires installing an external toolchain for C/C++ development. Below a
 - Single command
 
     ```bash
-    cd problem_sets && clang -o leap/test.out leap/test.c leap/main.c ../Unity/src/unity.c && ./leap/test.out
+    clang -o tests/problem_sets/leap/test tests/problem_sets/leap/test.c \
+        problem_sets/leap/leap.c ../Unity/src/unity.c && \
+    ./tests/problem_sets/leap/test
     ```
 
 - Setting up tasks on VS Code 

--- a/tests/problem_sets/leap/test.c
+++ b/tests/problem_sets/leap/test.c
@@ -1,5 +1,5 @@
-#include "../../../Unity/src/unity.h"
-#include "leap.h"
+#include "../../../../Unity/src/unity.h"
+#include "../../../problem_sets/leap/leap.h"
 
 // Optional hooks for setup and teardown (can be left empty if not needed)
 void setUp(void) {}

--- a/tests/sort.c
+++ b/tests/sort.c
@@ -1,0 +1,13 @@
+#include "sort.h"
+
+void bubble_sort(int *arr, int n) {
+    for (int i = 0; i < n - 1; ++i) {
+        for (int j = 0; j < n - i - 1; ++j) {
+            if (arr[j] > arr[j + 1]) {
+                int temp = arr[j];
+                arr[j] = arr[j + 1];
+                arr[j + 1] = temp;
+            }
+        }
+    }
+}

--- a/tests/sort.h
+++ b/tests/sort.h
@@ -1,0 +1,6 @@
+#ifndef SORT_H
+#define SORT_H
+
+void bubble_sort(int *arr, int n);
+
+#endif // SORT_H

--- a/tests/stack.c
+++ b/tests/stack.c
@@ -1,0 +1,34 @@
+#include "stack.h"
+
+void stack_init(Stack *s) {
+    s->top = -1;
+}
+
+bool stack_push(Stack *s, int value) {
+    if (s->top >= STACK_MAX - 1) {
+        return false;
+    }
+    s->data[++s->top] = value;
+    return true;
+}
+
+bool stack_pop(Stack *s, int *value) {
+    if (s->top < 0) {
+        return false;
+    }
+    if (value) {
+        *value = s->data[s->top];
+    }
+    s->top--;
+    return true;
+}
+
+bool stack_peek(const Stack *s, int *value) {
+    if (s->top < 0) {
+        return false;
+    }
+    if (value) {
+        *value = s->data[s->top];
+    }
+    return true;
+}

--- a/tests/stack.h
+++ b/tests/stack.h
@@ -1,0 +1,18 @@
+#ifndef STACK_H
+#define STACK_H
+
+#include <stdbool.h>
+
+#define STACK_MAX 100
+
+typedef struct {
+    int data[STACK_MAX];
+    int top;
+} Stack;
+
+void stack_init(Stack *s);
+bool stack_push(Stack *s, int value);
+bool stack_pop(Stack *s, int *value);
+bool stack_peek(const Stack *s, int *value);
+
+#endif // STACK_H

--- a/tests/test.c
+++ b/tests/test.c
@@ -1,0 +1,36 @@
+#include "../../Unity/src/unity.h"
+#include "stack.h"
+#include "sort.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_stack_push_pop_peek(void) {
+    Stack s;
+    int value;
+    stack_init(&s);
+    TEST_ASSERT_TRUE(stack_push(&s, 10));
+    TEST_ASSERT_TRUE(stack_peek(&s, &value));
+    TEST_ASSERT_EQUAL_INT(10, value);
+    TEST_ASSERT_TRUE(stack_push(&s, 20));
+    TEST_ASSERT_TRUE(stack_pop(&s, &value));
+    TEST_ASSERT_EQUAL_INT(20, value);
+    TEST_ASSERT_TRUE(stack_peek(&s, &value));
+    TEST_ASSERT_EQUAL_INT(10, value);
+}
+
+void test_bubble_sort(void) {
+    int arr[5] = {5, 1, 4, 2, 8};
+    bubble_sort(arr, 5);
+    int expected[5] = {1, 2, 4, 5, 8};
+    for (int i = 0; i < 5; ++i) {
+        TEST_ASSERT_EQUAL_INT(expected[i], arr[i]);
+    }
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_stack_push_pop_peek);
+    RUN_TEST(test_bubble_sort);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- move leap tests under tests/ to mirror repo structure
- update VS Code tasks to use new test locations
- adjust README example for running the leap test

## Testing
- `clang -o tests/test tests/test.c tests/stack.c tests/sort.c ../Unity/src/unity.c`
- `./tests/test`
- `clang -o tests/problem_sets/leap/test tests/problem_sets/leap/test.c problem_sets/leap/leap.c ../Unity/src/unity.c`
- `./tests/problem_sets/leap/test`


------
https://chatgpt.com/codex/tasks/task_e_686576189bd08332a15d6a97fce3c7a9