### PR TITLE
Add CI workflow with tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential git
+      - name: Run tests
+        run: bash scripts/run_tests.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Instructions for Contributors
+
+- Run `bash scripts/run_tests.sh` before committing to verify that all C sources compile and tests pass.
+- Format any C/C++ source files you modify using `clang-format` with the LLVM style.
+- Update the README if you add new examples or folders.
+- Keep the repository history linear; avoid creating new branches when submitting changes.

--- a/problem_sets/leap/test.c
+++ b/problem_sets/leap/test.c
@@ -1,4 +1,4 @@
-#include "../../../Unity/src/unity.h"
+#include "../../Unity/src/unity.h"
 #include "leap.h"
 
 // Optional hooks for setup and teardown (can be left empty if not needed)

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# compile all C files (except Unity sources) to ensure they build
+for cfile in $(find . -name "*.c" -not -path "./Unity/*" -not -path "./problem_sets/leap/test.c"); do
+    base=$(basename "$cfile")
+    if [ "$base" = "unity.c" ]; then
+        continue
+    fi
+    obj="/tmp/$(basename "$cfile" .c).o"
+    gcc -std=c11 -Wall -Wextra -c "$cfile" -o "$obj"
+    rm -f "$obj"
+done
+
+echo "All sources compiled successfully"
+
+# clone Unity if not present
+if [ ! -d Unity ]; then
+    git clone --depth 1 https://github.com/ThrowTheSwitch/Unity.git
+fi
+
+# build and run leap tests
+gcc problem_sets/leap/test.c problem_sets/leap/leap.c Unity/src/unity.c -I Unity/src -o leap_tests
+./leap_tests


### PR DESCRIPTION
## Summary
- add contributor instructions in AGENTS.md
- add workflow for GCC build and tests
- add helper script to compile sources and run Unity tests
- fix Unity include path for leap problem set

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68657ad794088332ac58eba0af6afe49