### PR TITLE
Validate dynamic array size input to prevent allocation overflow

### DIFF
--- a/memory_operations/dynamic_memory/dynamic_array.c
+++ b/memory_operations/dynamic_memory/dynamic_array.c
@@ -1,3 +1,5 @@
+#include <errno.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -5,11 +7,23 @@ int main(int argc, char **argv) {
   size_t count = 5;
 
   if (argc > 1) {
-    count = (size_t)strtoul(argv[1], NULL, 10);
-    if (count == 0) {
-      fprintf(stderr, "Provide a positive array size.\n");
+    char *endptr = NULL;
+    unsigned long parsed = 0;
+
+    errno = 0;
+    parsed = strtoul(argv[1], &endptr, 10);
+
+    if (errno == ERANGE || endptr == argv[1] || *endptr != '\0') {
+      fprintf(stderr, "Provide a valid positive array size.\n");
       return 1;
     }
+
+    if (parsed == 0 || parsed > SIZE_MAX / sizeof(int)) {
+      fprintf(stderr, "Provide a positive array size within limits.\n");
+      return 1;
+    }
+
+    count = (size_t)parsed;
   }
 
   int *values = calloc(count, sizeof(int));


### PR DESCRIPTION
### Motivation
- Prevent a buffer overflow caused by unbounded `strtoul` input where `count * sizeof(int)` could overflow and `calloc` allocate a smaller buffer than intended.
- Make the example robust by validating `strtoul` results and ensuring the requested element count fits in memory (`SIZE_MAX / sizeof(int)`).

### Description
- Add `#include <errno.h>` and `#include <stdint.h>` and parse the command-line size using `strtoul` with an `endptr` to detect invalid or partial parses.
- Check `errno == ERANGE` and that the input is numeric (`endptr != argv[1]` and `*endptr == '\0'`) and reject invalid inputs with a clear error message.
- Validate `parsed == 0` and `parsed > SIZE_MAX / sizeof(int)` to avoid overflow when computing allocation size, then set `count = (size_t)parsed` if valid.
- Keep the rest of the program logic unchanged and apply formatting with `clang-format -style=LLVM`.

### Testing
- Ran `clang-format -style=LLVM -i memory_operations/dynamic_memory/dynamic_array.c` and then `bash scripts/run_tests.sh` to ensure compilation and tests.
- All sources compiled successfully and the test suites executed with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969cdd3c6f083329e40b3f52e0b2b8f)